### PR TITLE
Remark mandatory step in ACS Deploy guide

### DIFF
--- a/documentation/modules/ROOT/pages/02-getting_started.adoc
+++ b/documentation/modules/ROOT/pages/02-getting_started.adoc
@@ -12,7 +12,7 @@ The three options depicted are:
 * Option 2 - Deploying ACS with Ansible (if you're in a rush and/or love Ansible)
 * Option 3 - Deploying ACS with Openshift GitOps (the GitOps way!)
 
-IMPORTANT: Independently on how you're installing, please deploy the deploy in the last step of ACS Deploy Demo to complete this module.
+IMPORTANT: Independently on how you're installing, please https://redhat-scholars.github.io/acs-workshop/acs-workshop/02-getting_started.html#deploy_demo_acs[follow the Mandatory deploy step] of ACS Deploy Demo to complete this module.
 
 [#install_acs_operator]
 == ACS Operator Install - Option 1


### PR DESCRIPTION
Edited the caption regarding the mandatory step to reflect the importance and avoid the 'deploy the deploy' sentence.