### PR TITLE
Fix extra variable in Getting Started section

### DIFF
--- a/documentation/modules/ROOT/pages/02-getting_started.adoc
+++ b/documentation/modules/ROOT/pages/02-getting_started.adoc
@@ -271,7 +271,7 @@ WARNING: you must be logged to the OpenShift cluster before you execute the play
 [.console-input]
 [source,bash,subs="attributes+,+macros"]	
 ----
-ansible-playbook rhacs-demo.yaml -e ocp4_workload_stackrox_central_admin_password=[your_pass]<1>
+ansible-playbook rhacs-demo.yaml -e stackrox_central_admin_password=[your_pass]<1>
 ----
 <1> The same password you obtained in the step 1 of the ``ACS login`` section.
 


### PR DESCRIPTION
Looks like this was a copy/paste issue from the agnosticd role :) the `rhacs-demo.yaml` playbook in https://github.com/rh-mobb/rhacs-demo doesn't leverage the `ocp4_workload_` prefix, and so results in the following error when run as written: 
```
TASK [ocp4_deploy_acs_demo_apps : Apply/update policies] **************************************************************************************************************
[WARNING]: Module did not set no_log for password
failed: [localhost] (item=/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/cvss_7.json) => {"ansible_loop_var": "item", "changed": false, "connection": "close", "content_length": "190", "content_type": "application/json", "date": "Mon, 27 Jun 2022 15:29:23 GMT", "elapsed": 0, "item": "/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/cvss_7.json", "json": {"code": 16, "details": [], "error": "credentials not found: not authorized: invalid username and/or password", "message": "credentials not found: not authorized: invalid username and/or password"}, "msg": "Status code was 401 and not [200]: HTTP Error 401: Unauthorized", "redirected": false, "status": 401, "url": "https://central-********.apps.cluster-pz84l.pz84l.sandbox1139.opentlc.com/v1/policies/import", "vary": "Accept-Encoding"}
failed: [localhost] (item=/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/process_uid_0.json) => {"ansible_loop_var": "item", "changed": false, "connection": "close", "content_length": "190", "content_type": "application/json", "date": "Mon, 27 Jun 2022 15:29:24 GMT", "elapsed": 0, "item": "/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/process_uid_0.json", "json": {"code": 16, "details": [], "error": "credentials not found: not authorized: invalid username and/or password", "message": "credentials not found: not authorized: invalid username and/or password"}, "msg": "Status code was 401 and not [200]: HTTP Error 401: Unauthorized", "redirected": false, "status": 401, "url": "https://central-********.apps.cluster-pz84l.pz84l.sandbox1139.opentlc.com/v1/policies/import", "vary": "Accept-Encoding"}
failed: [localhost] (item=/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/read_write_root_fs.json) => {"ansible_loop_var": "item", "changed": false, "connection": "close", "content_length": "190", "content_type": "application/json", "date": "Mon, 27 Jun 2022 15:29:24 GMT", "elapsed": 0, "item": "/Users/akrohg/projects/acs-workshop/rhacs-demo/roles/ocp4_deploy_acs_demo_apps/files/policies/read_write_root_fs.json", "json": {"code": 16, "details": [], "error": "credentials not found: not authorized: invalid username and/or password", "message": "credentials not found: not authorized: invalid username and/or password"}, "msg": "Status code was 401 and not [200]: HTTP Error 401: Unauthorized", "redirected": false, "status": 401, "url": "https://central-********.apps.cluster-pz84l.pz84l.sandbox1139.opentlc.com/v1/policies/import", "vary": "Accept-Encoding"}
```