### PR TITLE
Update 02-getting_started.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/02-getting_started.adoc
+++ b/documentation/modules/ROOT/pages/02-getting_started.adoc
@@ -348,7 +348,7 @@ metadata:
 spec:
   channel: stable
   installPlanApproval: Automatic
-  name: stable
+  name: rhacs-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----


### PR DESCRIPTION
fix the subscription name to avoid ConstraintsNotSatisfiable error

```
    - lastTransitionTime: "2024-03-25T12:17:51Z"
      message: all available catalogsources are healthy
      reason: AllCatalogSourcesHealthy
      status: "False"                          
      type: CatalogSourcesUnhealthy
    - message: 'constraints not satisfiable: no operators found in package stable
        in the catalog referenced by subscription rhacs-operator, subscription rhacs-operator
        exists'                                
      reason: ConstraintsNotSatisfiable
      status: "True"                           
      type: ResolutionFailed
    lastUpdated: "2024-03-25T12:17:51Z"

```